### PR TITLE
[0321] 14658번 - 하늘에서 별똥별이 빗발친다

### DIFF
--- a/python/하늘에서_별똥별이_빗발친다.py
+++ b/python/하늘에서_별똥별이_빗발친다.py
@@ -1,0 +1,22 @@
+import sys
+input = sys.stdin.readline
+
+n, m, l, k = map(int, input().split())
+stars = [tuple(map(int, input().split())) for _ in range(k)]
+
+max_count = 0
+
+for i in range(k):
+    x_start = stars[i][0]
+    for j in range(k):
+        y_start = stars[j][1]
+        cnt = 0
+        x_end = x_start + l
+        y_end = y_start + l
+        for (x, y) in stars:
+            if x_start <= x <= x_end and y_start <= y <= y_end:
+                cnt += 1
+        
+        max_count = max(max_count, cnt)
+
+print(k - max_count)


### PR DESCRIPTION
## 📎 문제 링크
https://www.acmicpc.net/problem/14658
<br/>

## 📝 풀이 내용
> k개의 별똥별이 주어지면 길이 l인 정사각형 안에 최대한 많이 넣을 수 있도록 배치하는 문제

처음에는 
K (별똥별의 개수)가 100 이하인 조건을 처음에 못봤다.

모든 경우의 정사각형 트램펄린 배치를 시도했다가 시간 초과

조건을 본 후에는
모든 별똥별을 트램펄린의 우상단, 좌상단, 우하단, 좌하단으로 놓고 풀어 실패
별똥별이 꼭지점에 있지 않은 경우를 빼먹어서 실패했다
(밑에 그림에 핑크색 부분)

모든 별똥별의 x를 기준으로 y 순회하며 계산 : k^3
이렇게 해서 성공!

<img width="662" alt="Image" src="https://github.com/user-attachments/assets/b895861d-f6a5-4ad1-999f-5046db1caeb4" />
<br/>

## **💬** 리뷰 요구사항
> 조건을 잘 보자!
이문제에서는 k^3이 충분하지만 더 좋은 방법이 있을 것 같기두,,

<br/>
