### PR TITLE
[0429] 2179번 - 비슷한 단어

### DIFF
--- a/C++/String/2179.cpp
+++ b/C++/String/2179.cpp
@@ -1,0 +1,129 @@
+#include <iostream>
+#include <vector>
+#include <map>
+#include <algorithm>
+using namespace std;
+
+int N;
+string str1, str2;
+pair<string, int> prefix;
+vector<pair<string, int>> words;
+map<string, vector<pair<int, string>>> m;
+
+void input(void)
+{
+    cin >> N;
+    for(int i = 0; i < N; i++)
+    {
+        string word; cin >> word;
+        words.push_back({word, i});
+        if (i == 0)
+            str1 = word;
+        if (i == 1)
+            str2 = word;
+    }
+    sort(words.begin(), words.end());
+}
+
+int countPrefix(string prev, string cur)
+{
+    int cnt = 0;
+    while (cnt < cur.size() && cnt < prev.size())
+    {
+        if (cur[cnt] != prev[cnt])
+            break;
+        cnt++;
+    }
+    return (cnt);
+}
+
+void updateLongestPrefix(int cnt, string curPrefix)
+{
+    // 새로운 최대 접두사 저장
+    if (cnt > prefix.first.length())
+    {
+        prefix.first = curPrefix;
+        prefix.second = m[curPrefix][0].first;
+    }
+    // 동일 길이 접두사가 나온다면 입력 순서 비교하기
+    else if (cnt == prefix.first.length())
+    {
+        int inputIndex = prefix.second;
+
+        if (inputIndex > m[curPrefix][0].first)
+        {
+            prefix.first = curPrefix;
+            prefix.second = m[curPrefix][0].first;
+        }
+    }
+}
+
+void saveStringInPrefixGroup(string curPrefix, int i, string prev, string cur)
+{
+    if (m[curPrefix].size() == 0)   // 새로운 prefix 저장
+    {
+        if (words[i].second < words[i - 1].second)
+        {
+            m[curPrefix].push_back({words[i].second, cur});
+            m[curPrefix].push_back({words[i - 1].second, prev});
+        }
+        else
+        {
+            m[curPrefix].push_back({words[i - 1].second, prev});
+            m[curPrefix].push_back({words[i].second, cur});
+        }
+    }
+    else  // 기존 prefix에 저장 
+    {
+        if (m[curPrefix][0].first > words[i].second)
+        {
+            m[curPrefix][1].first = m[curPrefix][0].first;
+            m[curPrefix][1].second = m[curPrefix][0].second;
+            m[curPrefix][0].first = words[i].second;
+            m[curPrefix][0].second = words[i].first;
+        }
+        else if (m[curPrefix][1].first > words[i].second)
+        {
+            m[curPrefix][1].first = words[i].second;
+            m[curPrefix][1].second = words[i].first;
+        }
+    }
+}
+
+void solve(void)
+{
+    for(int i = 1; i < N; i++)
+    {
+        string cur = words[i].first;
+        string prev = words[i - 1].first;
+        int cnt = countPrefix(prev, cur);
+
+        if (cur == prev)
+            continue;
+
+        if (cnt == 0)
+            continue;
+
+        string curPrefix = cur.substr(0, cnt);
+        saveStringInPrefixGroup(curPrefix, i, prev, cur);
+        updateLongestPrefix(cnt, curPrefix);
+    }
+}
+
+void output(void)
+{
+    if (prefix.first != "")
+    {
+        str1 = m[prefix.first][0].second;
+        str2 = m[prefix.first][1].second;
+    }
+    cout << str1 << "\n" << str2;
+}
+
+int main(void)
+{
+    input();
+    solve();
+    output();
+    return (0);
+}


### PR DESCRIPTION
## 📎 문제 링크
https://www.acmicpc.net/problem/2179

<br/>

## 📝 풀이 내용
> 풀이 내용, 고민한 부분 등을 작성해주세요

**최종 풀이**

1. 문자열과 입력 순서 모두를 벡터에 저장
2. 알파벳 순으로 정렬
3. 같은 접두사를 가지는 문자열을 접두사를 key로 하는 맵에 저장
    1. 우리는 입력 순서가 가장 빠른 두 문자열만 필요하기 때문에 맵에 저장할때 원소를 2개로  유지시켜주었다.
4. 접두사 갱신
    1. 기존 접두사보다 현재 접두사가 더 길다면 현재 접두사로 대체
    2. 기존 접두사와 현재 접두사의 길이가 같다면, 기존 접두사를 가지는 문자열 중 가장 빠른 입력 순서와 현재 접두사를 가지는 문자열 중 가장 빠른 입력 순서를 비교해 더 빠른 입력 순서를 가지는 쪽으로 대체

<br/>

## **💬** 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<img width="1050" alt="스크린샷 2025-04-29 오후 10 35 13" src="https://github.com/user-attachments/assets/19ec57eb-76ea-4349-88b6-62616962bce3" />

짠.. 3일에 걸쳐서 풀었어요
만날 수 있는 에러는 다 만났어요,, 🥺
풀릴듯 말듯 정말 간지러운 문제였습니다.. 
더 간단한 풀이가 있을거 같은데 이게 정말 최선일까....??? 궁금합니다,,

<br/>
