### PR TITLE
[0928] 2309번 - 일곱 난쟁이

### DIFF
--- a/src/Baekjoon/codingdodo/bruteforce/Q2309.java
+++ b/src/Baekjoon/codingdodo/bruteforce/Q2309.java
@@ -1,0 +1,45 @@
+package Baekjoon.codingdodo.bruteforce;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class Q2309 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int arr[] = new int[9];
+        int total = 0;
+        for(int i=0;i<9;i++){
+            arr[i] = Integer.parseInt(br.readLine());
+            total += arr[i];
+        }
+
+        Arrays.sort(arr); // 오름차순 정렬
+
+        int sum = 0;
+        for(int i=0;i<9;i++){
+            for(int j=i+1;j<9;j++){
+                sum = arr[i] + arr[j];
+
+                if(total - sum == 100){
+                    StringBuilder sb = new StringBuilder();
+
+                    for(int k=0;k<9;k++){
+                        if(k != i && k != j){
+                            sb.append(arr[k]).append("\n");
+                        }
+                    }
+                    // 마지막 개행 제거
+                    if(sb.length()>0){
+                        sb.setLength(sb.length()-1);
+                    }
+
+                    System.out.print(sb.toString());
+                    return;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📎 문제 링크
https://www.acmicpc.net/problem/2309
<br/>

## 📝 풀이 내용
> 풀이 내용, 고민한 부분 등을 작성해주세요

브루트 포스 첨 풀어본댱....ㅎㅎ..

일단 문제 조건은 "9명의 난쟁이 중 키의 합이 100이 되는 7명"을 찾는거였는데
브루트포스 유형이 가능한 모든 경우의 수를 전부 탐색해서 답을 찾는거라해서...
for문을 9\*8\*7*.....(7번) 하라는건가...?했는데 말이 안되는 거 같아서 조금 더 고민해봤다.

그래서 내가 쓴 풀이 방법은... 
9명의 키를 다 더하고, 2명 키의 합을 뺐을 때, 조건에 맞으면 반환하도록 했다.
-> 이러면 2명 조합만 만들어내면 되기 때문에 for문을 9*8만 하면 된다.

글고 오름차순으로 반환하라 해서 처음부터 sort 하고 시작했다. 
-> 위의 for문 안에서 조건에 맞으면, 바로 출력하도록 했는데
 (맨 첨에 안하고) 거기서 sort를 하게 되면, 제외된 2명의 인덱스 골라놨던 게 변해버리기 때문에 그랬다.

<br/>

## **💬** 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>
