### PR TITLE
[0930] 11724번 - 연결 요소의 개수

### DIFF
--- a/src/Baekjoon/codingdodo/dfs/DFS.java
+++ b/src/Baekjoon/codingdodo/dfs/DFS.java
@@ -1,0 +1,37 @@
+package Baekjoon.codingdodo.dfs;
+
+import java.util.List;
+import java.util.Stack;
+
+public class DFS {
+    void dfsStack(int start, boolean[] visited, List<List<Integer>> graph){
+        Stack<Integer> stack = new Stack<>();
+        stack.push(start); // 시작 노드를 스택에 넣음
+
+        while(!stack.isEmpty()){ // 스택이 비워질 때까지 반복
+            int node = stack.pop(); // 스택에서 맨 위 정점 가져오기
+            if (!visited[node]){ // 방문하지 않은 정점
+                visited[node] = true; // 방문 처리
+                System.out.print(node + " "); // 방문 출력
+
+                for(int next: graph.get(node)){
+                    if(!visited[next]){
+                        stack.push(next); // 나중에 방문할 노드를 스택에 넣기
+                    }
+                }
+            }
+        }
+    }
+
+    void dfsRecursive(int node, boolean[] visited, List<List<Integer>> graph){
+        visited[node] = true; // 현재 노드 방문 처리
+        System.out.print(node + " "); // 방문 출력
+
+        for(int next: graph.get(node)){
+            if(!visited[next]){
+                dfsRecursive(next, visited, graph); // 재귀 호출
+            }
+        }
+    }
+
+}

--- a/src/Baekjoon/codingdodo/dfs/Q11724.java
+++ b/src/Baekjoon/codingdodo/dfs/Q11724.java
@@ -1,0 +1,60 @@
+package Baekjoon.codingdodo.dfs;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Q11724 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        List<List<Integer>> graph = new ArrayList<>();
+        for(int i = 0; i <= N; i++) {
+            graph.add(new ArrayList<>());
+        }
+
+        for(int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+
+            graph.get(a).add(b);
+            graph.get(b).add(a); // 무방향 그래프일 때 ⭐⭐🌠🌠🌠
+        }
+
+        System.out.println(graph);
+        boolean[] visited = new boolean[N+1];
+
+        int connect = 0;
+        for(int i = 1; i <= N; i++) {
+            if(!visited[i]) {
+                // System.out.println(i + "부터 시작한 DFS 탐색 결과: ");
+                dfsRecursive(i,visited,graph);
+                // System.out.println();
+                connect++;
+            }
+        }
+
+        // System.out.println();
+        // System.out.println("연결 노드 수: ");
+        System.out.print(connect);
+    }
+
+    static void dfsRecursive(int node, boolean[] visited, List<List<Integer>> graph){
+        visited[node] = true; // 현재 노드 방문 처리
+        // System.out.print(node + " "); // 방문 출력
+
+        for(int next: graph.get(node)){
+            if(!visited[next]){
+                dfsRecursive(next, visited, graph); // 재귀 호출
+            }
+        }
+    }
+}

--- a/src/Baekjoon/codingdodo/dfs/dfsPractice.java
+++ b/src/Baekjoon/codingdodo/dfs/dfsPractice.java
@@ -1,0 +1,36 @@
+package Baekjoon.codingdodo.dfs;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class dfsPractice {
+    public static void main(String[] args) {
+        // 그래프 크기(정점 개수)
+        int n = 5;
+
+        // 인접 리스트 초기화
+        List<List<Integer>> graph = new ArrayList<>();
+        for (int i = 0; i <= n; i++) {
+            graph.add(new ArrayList<>());
+        }
+
+        // 간선 추가(양방향 그래프)
+        graph.get(1).add(2);
+        graph.get(1).add(4);
+        graph.get(2).add(1);
+        graph.get(2).add(3);
+        graph.get(3).add(2);
+        graph.get(4).add(1);
+        graph.get(4).add(5);
+        graph.get(5).add(4);
+
+        // 방문 배열
+        boolean[] visited = new boolean[n+1];
+
+        // DFS 실행
+        DFS dfs = new DFS();
+        System.out.println("DFS 탐색 결과: ");
+        dfs.dfsStack(1,visited,graph);
+        // dfs.dfsRecursive(1,visited,graph);
+    }
+}


### PR DESCRIPTION
## 📎 문제 링크
https://www.acmicpc.net/problem/11724
<br/>

## 📝 풀이 내용
> 풀이 내용, 고민한 부분 등을 작성해주세요

dfs 첨 풀어봤당

풀기 전에 일단 dfs 자체를 공부해보고, 문제에 적용해봤다.

### DFS
dfs는 **스택**으로 푸는 법이랑 **재귀**로 푸는 방법 2가지가 있다.
코드 자체는 재귀가 간단한데, 이해하기에는 스택이 좀 더 쉬웠다.

둘의 차이는 **backtracking**에서 있는 거 같은데
스택은 그냥 `stack.pop()`해서, 스택에 남아있는 거를 꺼내는 거니까 이해하기 쉬웠는데
재귀는  좀 어려웠당...
<img width="500" height="877" alt="image" src="https://github.com/user-attachments/assets/6c660e27-b340-40f3-a584-5657be3a359e" />
그래서 그림을 그려봤더니 조금 이해가 된 것 같기도 하댜.
-> 코드로 쓰자니 좀 어렵긴 한데.. 외워서 풀면 되게찌?????

### 연결 노드 개수 구하기
존재하는 연결 노드만 구하면 되는 문제였다.
내가 생각한 방법은
1) 끝까지 방문하면 연결노드수+1
2) 방문 안 한 노드 중에서 새로 출발 -> 반복

근데 2) 방문 안 한 노드 중에서 새로 출발하는 걸 어떻게 하는지 모르겠어서...... 쥐피티한테 물어봤다.
그냥 **for문으로 전체 visited 배열 순회하면서** 방문 안 한 노드는 전부 dfs 돌리면 되는 거였다.
사실 이러면 1), 2)를 굳이 분리할 필요 없었던 것 같다.
-> 이게 가능한 이유는 시작 정점이 중요하지 않아서인가?

### 무방향 그래프
첨에 인접리스트에 간선 추가할 때
`graph.get(a).add(b);` 만 했었는데 이러면 방향 그래프이고,
`graph.get(b).add(a);` 도 해줘야 양쪽으로도 이동할 수 있는 무방향 그래프가 완성된다.
까먹지 않기 위해 별⭐🌠표시를 해줬당 ㅎㅎ

<br/>

## **💬** 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>
