### PR TITLE
[1001] 11403번 - 경로 찾기

### DIFF
--- a/src/Baekjoon/codingdodo/dfs/Q11403.java
+++ b/src/Baekjoon/codingdodo/dfs/Q11403.java
@@ -1,0 +1,59 @@
+package Baekjoon.codingdodo.dfs;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Q11403 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+
+        List<List<Integer>> graph = new ArrayList<>();
+        for (int i = 0; i < N; i++) {
+            graph.add(new ArrayList<>());
+        }
+
+        for(int i=0;i<N;i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for(int j=0;j<N;j++){
+                if(Integer.parseInt(st.nextToken()) == 1){
+                    graph.get(i).add(j);
+                }
+            }
+        }
+
+        // System.out.println(graph);
+
+        for(int i=0;i<N;i++){
+            for(int j=0;j<N;j++){
+                boolean[] visited = new boolean[N];
+                System.out.print((dfsRecursive(i,j,visited,graph) ? 1 : 0) + " ");
+            }
+            if(i!=N-1){
+                System.out.println();
+            }
+        }
+    }
+
+    static boolean dfsRecursive(int node,int destination, boolean[] visited, List<List<Integer>> graph){
+        visited[node] = true; // 현재 노드 방문 처리
+        // System.out.print("'"+node +"'"+ " "); // 방문 출력
+
+        for(int next: graph.get(node)){
+            if(next==destination){ // 양수인 경로여야 함 -> 간선 하나 이상은 거쳐야 함.
+                return true;
+            }
+            if(!visited[next]){
+                if (dfsRecursive(next, destination, visited, graph)) {
+                    return true; // 목적지까지 갔다와서 true 반환 ⭐⭐⭐
+                }
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION
## 📎 문제 링크
https://www.acmicpc.net/problem/11403
<br/>

## 📝 풀이 내용
> 풀이 내용, 고민한 부분 등을 작성해주세요

오늘도 dfs를 풀었는데 좀 어려웠당........
dfs를 이런식으로 응용할 수도 있군.....!

### 재귀...
재귀 함수가 익숙하지 않아서 더 어려운 것 같다...
내가 젤 이해하기 어려웠던 부분은 

```
static boolean dfsRecursive(int node,int destination, boolean[] visited, List<List<Integer>> graph){
        visited[node] = true; // 현재 노드 방문 처리
        // System.out.print("'"+node +"'"+ " "); // 방문 출력

        for(int next: graph.get(node)){
            if(next==destination){ // 양수인 경로여야 함 -> 간선 하나 이상은 거쳐야 함.
                return true;
            }
            if(!visited[next]){
                if (dfsRecursive(next, destination, visited, graph)) {
                    return true; // 목적지까지 갔다와서 true 반환 ⭐⭐⭐
                }
            }
        }
        return false;
    }
```
중에서

```
if (dfsRecursive(next, destination, visited, graph)) {
                    return true; // 목적지까지 갔다와서 true 반환 ⭐⭐⭐
                }
```
이 부분이다.

여기서 왜 true를 반환해야 하는지 좀 헷갈렸는데
dfsRecursive를 호출했을 때, **끝까지 false에 한번도 걸리지 않고** 완주했으니 결과적으로 true를 주는 것 같다...
(맞나.....재귀를 완벽히 이해하게 된다면 이것이 맞는지 다시 고민해봐야겠댜)

어쨌든 결국 여기서 재귀 함수의 반환 값은 "경로의 존재 여부"라고 볼 수 있다.
- dfsRecursive(next, destination, ...)를 호출했을 때
  - true -> next에서 출발해 destination까지 갈 수 있었다는 뜻
  - false -> next에서 출발했지만 결국 못 갔다는 뜻

### 양수인 경로
또 고민했던 부분은 
첨에는
```
if(next==destination){ // 양수인 경로여야 함 -> 간선 하나 이상은 거쳐야 함.
                return true;
            }
```
이 부분을 dfsRecursive 함수의 맨 위에 넣었는데, 그러면 자기 자신과 도착지가 같을 경우에, **한번도 경로를 돌지 않더라도** 경로가 있는 것으로 쳐서 안된다는 것을 깨달았다. 문제의 조건은 '**양수 길이의 경로**'이기 때문에, 길이가 0인 저 경우는 빠지도록, **next**(적어도 1번은 경로를 거치는)와 도착지를 비교하도록 바꿨다. 

### 이것이 최선의 풀이인가..
이 문제는 **플로이드-워셜**로도 풀 수 있다는데 그걸로도 풀어보고 뭐가 더 좋은 방법인지 고민해봐야겠다.
<br/>

## **💬** 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>
