### PR TITLE
[1013] 1012번 - 유기농 배추 

### DIFF
--- a/src/Baekjoon/codingdodo/bfs/Q1012.java
+++ b/src/Baekjoon/codingdodo/bfs/Q1012.java
@@ -1,0 +1,85 @@
+package Baekjoon.codingdodo.bfs;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class Q1012 {
+    static int M;
+    static int N;
+    static boolean[][] visited;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int T = Integer.parseInt(br.readLine());
+
+        for(int i=0;i<T;i++){
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            M = Integer.parseInt(st.nextToken());
+            N = Integer.parseInt(st.nextToken());
+            int K = Integer.parseInt(st.nextToken());
+
+            int[][] arr = new int[N][M];
+
+            for(int j=0;j<K;j++){
+                st = new StringTokenizer(br.readLine());
+                int X = Integer.parseInt(st.nextToken());
+                int Y = Integer.parseInt(st.nextToken());
+                arr[Y][X] = 1;
+            }
+
+            /*
+            for(int j=0;j<N;j++){
+                for(int k=0;k<M;k++){
+                    System.out.print(arr[j][k] + " ");
+                }
+                System.out.println();
+            }
+             */
+
+            visited = new boolean[N][M];
+
+            int total = 0;
+            for(int j=0;j<N;j++){
+                for(int k=0;k<M;k++){
+                    if(!visited[j][k] && arr[j][k] == 1){
+                        bfsQueue(k,j,arr);
+                        // System.out.println();
+                        total++;
+                    }
+                }
+            }
+
+            System.out.println(total);
+        }
+    }
+
+    static int[] dx = {0,1,0,-1};
+    static int[] dy = {-1,0,1,0};
+    static void bfsQueue(int x,int y,int[][] arr){
+        Queue<int[]> queue = new LinkedList<>();
+        queue.add(new int[] {x,y}); // 시작 노드를 큐에 삽입
+        visited[y][x] = true; // 방문 처리
+
+        while(!queue.isEmpty()){ // 큐가 빌 때까지 반복
+            int[] node = queue.poll(); // 큐에서 맨 앞 노드 꺼내기
+            // System.out.print(node[0] +","+node[1]+ "    "); // 방문 출력
+
+            int nextX;
+            int nextY;
+            for(int i=0;i<4;i++){
+                nextX = node[0] + dx[i];
+                nextY = node[1] + dy[i];
+                if((nextX>=0 && nextX<M && nextY>=0 && nextY<N)
+                        &&(!visited[nextY][nextX])
+                        && (arr[nextY][nextX] == 1)){
+                    visited[nextY][nextX] = true; // 방문 처리
+                    queue.add(new int[] {nextX,nextY}); // 큐에 삽입
+                }
+            }
+        }
+    }
+}

--- a/src/Baekjoon/codingdodo/bfs/Q1012_2.java
+++ b/src/Baekjoon/codingdodo/bfs/Q1012_2.java
@@ -1,0 +1,73 @@
+package Baekjoon.codingdodo.bfs;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+// visited 없이 방문 처리하기
+public class Q1012_2 {
+    static int N,M;
+    static int[] dx = {-1, 0, 1, 0};
+    static int[] dy = {0, 1, 0, -1};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int T = Integer.parseInt(br.readLine());
+
+        while(T-- > 0) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            M = Integer.parseInt(st.nextToken());
+            N = Integer.parseInt(st.nextToken());
+            int K = Integer.parseInt(st.nextToken());
+
+            int[][] arr = new int[N][M];
+            while(K-- > 0){
+                st = new StringTokenizer(br.readLine());
+                int X = Integer.parseInt(st.nextToken());
+                int Y = Integer.parseInt(st.nextToken());
+
+                arr[Y][X] = 1;
+            }
+
+            int total = 0;
+            for(int i = 0; i < N; i++){
+                for(int j = 0; j < M; j++){
+                    if(arr[i][j] == 1){
+                        bfsQueue(j,i,arr);
+                        total++;
+                    }
+                }
+            }
+
+            System.out.println(total);
+        }
+
+    }
+
+    static void bfsQueue(int x,int y,int[][] arr){
+        Queue<int[]> queue = new LinkedList<>();
+        queue.add(new int[]{x,y});
+        arr[y][x] = 0;
+
+        while (!queue.isEmpty()){
+            int[] node = queue.poll();
+            // System.out.print(node[0] + "," + node[1] + " ");
+
+            int nx,ny;
+            for(int i=0;i<4;i++){
+                nx = node[0] + dx[i];
+                ny = node[1] + dy[i];
+
+                if((nx >=0 && nx < M && ny >= 0 && ny <N)
+                        && (arr[ny][nx] == 1)){
+                    queue.add(new int[]{nx,ny});
+                    arr[ny][nx] = 0;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 📎 문제 링크
https://www.acmicpc.net/problem/1012
<br/>

## 📝 풀이 내용
> 풀이 내용, 고민한 부분 등을 작성해주세요

2가지 실수 때문에 고생했다...
- visited를 static으로 안하고, bfsQueue의 인자로 넣기
  -> 이전 탐색에서 방문 처리한 정보가 다음 탐색에 공유되지 않음 
- 큐에 삽입할 때 new 안 쓰고, 같은 node배열을 수정해서 넣기
  -> 큐 안의 모든 노드가 같은 참조를 공유해버림 

근데 사실.. 지금까지 풀었던 dfs랑 bfs에서는 visited를 전역으로 두지 않아도 문제가 전혀 생기지 않았다...!🥲(그래서 이번에 오류를 찾기가 더 쉽지 않았다.....)
그래서 무슨 차이인지 생각해보았다...!!
- 지금까지 썼던 dfs는 재귀dfs여서 자기 자신을 재귀 호출하기 때문에, 모든 호출이 같은 visited를 호출해서 가능했다.
- 글고 전에 풀었던 bfs는 bfs를 딱 한번만 호출하면 되는 문제여서 가능했다.

근데 이번에는 bfs를 여러 번 호출하면서 visited를 공유해야하는 문제였는데
인자로 넣는 방식을 쓰니, bfsQueue()를 호출할 때마다 새로운 지역 visited가 생성되었던 것이다..!!

많은 깨달음이 있는 문제였당...

✔ bfs를 여러번 호출할 경우, **방문처리 정보가 전역으로 공유되도록** 주의하자!
✔ **배열 참조 주소 재사용하지 않도록** 주의하자!

+) visited없이 방문 처리하는 방식으로도 풀어봤다...!

<br/>

## **💬** 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>
