### PR TITLE
[1016] 14929번 - 귀찮아(SIB) 

### DIFF
--- a/src/Baekjoon/codingdodo/prefixsum/Q14929.java
+++ b/src/Baekjoon/codingdodo/prefixsum/Q14929.java
@@ -1,0 +1,53 @@
+package Baekjoon.codingdodo.prefixsum;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+// 2D
+public class Q14929 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine());
+
+        int[] num = new int[n];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            num[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int[][] arr = new int[n+1][n+1];
+        for(int i = 1; i <= n-1; i++){
+            for(int j = i+1; j <= n; j++){
+                arr[i][j] = num[i-1]*num[j-1];
+            }
+        }
+
+        int[][] prefix = new int[n+1][n+1];
+        for(int i = 1; i <= n; i++){
+            for(int j = 1; j <= n; j++){
+                prefix[i][j] = prefix[i-1][j] + prefix[i][j-1] - prefix[i-1][j-1] + arr[i][j];
+            }
+        }
+
+        /*
+        for(int i = 1; i <= n; i++){
+            for(int j = 1; j <= n; j++){
+                System.out.print(arr[i][j] + " ");
+            }
+            System.out.println();
+        }
+
+        for(int i = 1; i <= n; i++){
+            for(int j = 1; j <= n; j++){
+                System.out.print(prefix[i][j] + " ");
+            }
+            System.out.println();
+        }
+         */
+
+        System.out.println(prefix[n][n]);
+    }
+}

--- a/src/Baekjoon/codingdodo/prefixsum/Q14929_2.java
+++ b/src/Baekjoon/codingdodo/prefixsum/Q14929_2.java
@@ -1,0 +1,52 @@
+package Baekjoon.codingdodo.prefixsum;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+// 2D in_place
+public class Q14929_2 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine());
+
+        int[] num = new int[n];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            num[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int[][] arr = new int[n+1][n+1];
+        for(int i = 1; i <= n-1; i++){
+            for(int j = i+1; j <= n; j++){
+                arr[i][j] = num[i-1]*num[j-1];
+            }
+        }
+
+        for(int i = 1; i <= n; i++){
+            for(int j = 1; j <= n; j++){
+                arr[i][j] += arr[i-1][j] + arr[i][j-1] - arr[i-1][j-1];
+            }
+        }
+
+        /*
+        for(int i = 1; i <= n; i++){
+            for(int j = 1; j <= n; j++){
+                System.out.print(arr[i][j] + " ");
+            }
+            System.out.println();
+        }
+
+        for(int i = 1; i <= n; i++){
+            for(int j = 1; j <= n; j++){
+                System.out.print(prefix[i][j] + " ");
+            }
+            System.out.println();
+        }
+         */
+
+        System.out.println(arr[n][n]);
+    }
+}

--- a/src/Baekjoon/codingdodo/prefixsum/Q14929_3.java
+++ b/src/Baekjoon/codingdodo/prefixsum/Q14929_3.java
@@ -1,0 +1,30 @@
+package Baekjoon.codingdodo.prefixsum;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+// 배열 없이
+public class Q14929_3 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine());
+
+        int[] num = new int[n];
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < n; i++) {
+            num[i] = Integer.parseInt(st.nextToken());
+        }
+
+        int sum = 0;
+        for(int i = 1; i <= n-1; i++){
+            for(int j = i+1; j <= n; j++){
+                sum += num[i-1]*num[j-1];
+            }
+        }
+
+        System.out.println(sum);
+    }
+}

--- a/src/Baekjoon/codingdodo/prefixsum/Q14929_4.java
+++ b/src/Baekjoon/codingdodo/prefixsum/Q14929_4.java
@@ -1,0 +1,34 @@
+package Baekjoon.codingdodo.prefixsum;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+// split + BufferedWriter
+public class Q14929_4 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        int n = Integer.parseInt(br.readLine());
+
+        int[] num = new int[n];
+        String[] tokens = br.readLine().split(" ");
+        for (int i = 0; i < n; i++) {
+            num[i] = Integer.parseInt(tokens[i]);
+        }
+
+        int sum = 0;
+        for(int i = 1; i <= n-1; i++){
+            for(int j = i+1; j <= n; j++){
+                sum += num[i-1]*num[j-1];
+            }
+        }
+
+        bw.write(sum + "\n");
+        bw.flush();
+        bw.close();
+    }
+}

--- a/src/Baekjoon/codingdodo/prefixsum/Q14929_5.java
+++ b/src/Baekjoon/codingdodo/prefixsum/Q14929_5.java
@@ -1,0 +1,34 @@
+package Baekjoon.codingdodo.prefixsum;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+
+// O(N)
+public class Q14929_5 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        int n = Integer.parseInt(br.readLine());
+
+        int[] num = new int[n];
+        String[] tokens = br.readLine().split(" ");
+        for (int i = 0; i < n; i++) {
+            num[i] = Integer.parseInt(tokens[i]);
+        }
+
+        long sum = 0;
+        long prefix = 0;
+        for(int i=0 ; i<n ; i++){
+            sum += (long) num[i] * prefix;
+            prefix += num[i];
+        }
+
+        bw.write(sum + "\n");
+        bw.flush();
+        bw.close();
+    }
+}


### PR DESCRIPTION
## 📎 문제 링크
https://www.acmicpc.net/problem/14929
<br/>

## 📝 풀이 내용
> 풀이 내용, 고민한 부분 등을 작성해주세요

첨으로 **메모리 초과**를 마주했고.... 이걸 해결하고나니 **시간 초과**를 마주했다.....
그래서 총 4번의 리팩토링을 걸쳐.... 메모리도 아낄 수 있고 효율적인 코드를 작성하게 되었댜 !!

메모리 제한은 512MB, 시간 제한은 2초였다.

### 1) 1차 코드 - 2차원 배열 이용
첨엔 메모리 생각도 안해봤는데..
생각해보니 메모리를 말도 안되게 초과했었다...!ㅋㅋ
N이 10만 이하인데 int[N+1][N+1]을 만들었으닠ㅋㅋ
N = 10만
(N+1)² = 약 100억
100억 * 4바이트 = 400억 바이트 = 40GB = 약 4만MB.....

(근데 이걸 2개(arr 배열이랑 prefix 배열)나 만들었다)

### 2) 2차 코드 - in-place 연산 
2차 코드까진 위에처럼 메모리가 대충 얼마나 사용되는지도 계산하지 않고
그냥 prefix 배열을 따로 만들지 않고, arr배열을 업데이트하는 방식으로 
**배열 1개를 줄였다.**

하지만 당연히 이거만으로는 택도 없었고...

### 3) 3차 코드 - 배열 없애고, 이중 for문 이용해서 sum 바로 구하기
생각해보니 굳이 계산 결과를 다 저장할 필요 없이 **바로바로 더해서** sum을 구하면 됐다.
그랬더니 메모리는 거의 쓰지 않게 됐지만...

시간이 초과됐다!

### 4) 4차 코드 - 입출력 최적화
입출력에 시간이 많이 걸리나 싶어서
**StringTokenizer**로 한 줄씩 nextToken()을 계속 호출하던거를
**split**()을 이용해서 내부에서 한 번에 배열로 잘라버리도록 바꿨다.
그리고 **BufferedWriter**를 이용해서, 출력을 버퍼에 모았다가 한 번에 내보냈다.

그래도 시간이 초과됐다..

### 5) 최종!! - 단일for문 누적합 -> 시간복잡도 O(N)으로 개선 
시간 계산은 사실 어떻게 하는지 모르겠지만...
10만을 시간복잡도 O(N^2)으로 돌리게 되면 오래 걸릴 거 같긴 하다.

이거는 근데 시간복잡도를 O(N)으로 어떻게 줄일 수 있을지 진짜 모르겠어서 찾아봤다..

(사실 4차 코드까지 내가 누적합을 이용해서 푼건줄 알았는데.. 아녔다.ㅎ)

**단일 for문으로 누적합**을 쓰면 됐다!

<img width="500" height="1373" alt="image" src="https://github.com/user-attachments/assets/14cab8bf-6c16-4684-b583-51c714870de3" />

이런 느낌으로 한꺼번에 계산할 수 있게 되면서 O(N)으로 풀 수 있다!

힘든 여정이었다..
<br/>

## **💬** 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>
