### PR TITLE
[1024] 1309번 - 동물원

### DIFF
--- a/src/Baekjoon/solvedac/dynamicprogramming/Q1309.java
+++ b/src/Baekjoon/solvedac/dynamicprogramming/Q1309.java
@@ -1,0 +1,43 @@
+package Baekjoon.solvedac.dynamicprogramming;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Q1309 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int N = Integer.parseInt(br.readLine());
+
+        long[] dp_ox = new long[N];
+        long[] dp_xx = new long[N];
+        long[] dp_xo = new long[N];
+
+        dp_ox[0] = 2;
+        dp_xx[0] = 3;
+        dp_xo[0] = 2;
+
+        if(N > 1){
+            for(int i = 1; i < N-1; i++) {
+                dp_ox[i] = (dp_xx[i-1] + dp_xo[i-1])% 9901;
+                dp_xx[i] = (dp_ox[i-1] + dp_xx[i-1] + dp_xo[i-1])% 9901;
+                dp_xo[i] = (dp_ox[i-1] + dp_xx[i-1])% 9901;
+            }
+            long total = dp_ox[N-2] + dp_xx[N-2] + dp_xo[N-2];
+            System.out.println(total % 9901);
+        }
+
+        else {
+            System.out.println(3);
+        }
+        /*
+        for(int i = 0; i < N-1; i++) {
+            System.out.println(dp_ox[i] + " " + dp_xx[i] + " " + dp_xo[i] + " ");
+        }
+         */
+
+
+
+    }
+}


### PR DESCRIPTION
## 📎 문제 링크
https://www.acmicpc.net/problem/1309
<br/>

## 📝 풀이 내용
> 풀이 내용, 고민한 부분 등을 작성해주세요

전에 풀었던 RGB 문제 #162 랑 비슷하게 풀 수 있을 거 같은데...... 아이디어가 떠오를듯말듯해서 계속 째려봤다.

우선, RGB처럼 이전 행의 상태에 따라 현재 행에 제약이 생긴다는 것을 먼저 깨달았다.

다만, 첨에는 옆에껄 정해놓지 않고, 한쪽만 정해놓고 풀자니 옆꺼에 위에꺼도 영향을 받아서(?) 변수가 넘 많아졌다. (말로 표현하기 어렵네...)

그래서 결국 아예 행별로 ox, xx, xo로 나눴을 때는 윗 행이 무조건 결정될 수 있다는 것을 깨달았다.

<img width="300" height="2390" alt="image" src="https://github.com/user-attachments/assets/b4ec4d66-2441-4abc-913c-492b72bd5af0" />

그래서 이렇게 1차원 배열 3개를 만들고 
현재 행이 ox <- 이전 행은 xx or xo
현재 행이 xx <- 이전 행은 ox or xx or xo
현재 행이 xo <- 이전 행은 ox or xx
임을 이용해서 경우의 수를 더해주며 dp 배열을 업데이트 했다.

이걸을 2차원으로 푼다면 결국 RGB랑 똑같은 문제였다!!!!


9901로 나눈 나머지를 구해야하는데
마지막에만 해줬더니 틀렸다
어느 순간부터 오버플로가 날지 모르니 dp를 업데이트 해줄 때마다 mod연산을 해야하나보다 ..


<br/>

## **💬** 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>
