### PR TITLE
[1029] 1495번 - 기타리스트

### DIFF
--- a/src/Baekjoon/solvedac/dynamicprogramming/Q1495.java
+++ b/src/Baekjoon/solvedac/dynamicprogramming/Q1495.java
@@ -1,0 +1,66 @@
+package Baekjoon.solvedac.dynamicprogramming;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
+public class Q1495 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int S = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        int[] arr = new int[N+1];
+        st = new StringTokenizer(br.readLine());
+        for(int i = 1; i <= N; i++){
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        // dp[n] = m : "m번째 연주에서 볼륨 n으로 연주할 수 있음"
+        int[] dp = new int[M+1];
+
+        // 기본값 설정
+        for(int i=0;i<=M;i++){
+            dp[i] = -1;
+        }
+        dp[S] = 0; // 0번째 연주는 볼륨 5 (=시작 볼륨이 5)
+
+        for(int i = 1; i <= N; i++){ // 1~N 번째 연주
+            List<Integer> list = new ArrayList<>();
+
+            for(int j = 0; j <= M; j++){ // 0~M 사이의 볼륨
+                if(dp[j] == i-1){ // i-1번째 연주(0~N-1 사이)의 볼륨에다가
+                    int plus = j + arr[i]; // 더하거나
+                    int minus = j - arr[i]; // 빼기가
+
+                    // 가능한 경우 리스트에 추가
+                    if(0 <= plus && plus <= M){
+                        list.add(plus);
+                    }
+                    if(0 <= minus && minus <= M){
+                        list.add(minus);
+                    }
+                }
+            }
+
+            for(int n : list){
+                dp[n] = i;
+            }
+        }
+
+        int max = -1;
+        for(int i = 0; i <= M; i++){
+            if(dp[i] == N){
+                max = Math.max(max, i);
+            }
+        }
+
+        System.out.println(max);
+    }
+}


### PR DESCRIPTION
## 📎 문제 링크
https://www.acmicpc.net/problem/1495
<br/>

## 📝 풀이 내용
> 풀이 내용, 고민한 부분 등을 작성해주세요

아 넘 어려웠당...
여러 블로그 참고해서 풀었다..

핵심은
`dp[n] = m : "m번째 연주에서 볼륨 n으로 연주할 수 있음"` 이다.
이렇게 하면 해당 볼륨이 몇번째 연주 단계까지 가능한지를 기록할 수 있다. 
예를 들어,
dp[10] = 3은 볼륨 10이 3번째 연주까지 가능하다는 뜻이다.

시작 볼륨이 5이기 때문에 
초기화는 dp[5] = 0로 할 수 있고,
기본적으로는 -1로 초기화하여서 아직 도달할 수 없는 볼륨을 표시한다. 

1번째 연주는 +5 혹은 -5로 볼륨 조절할 수 있기 때문에
dp[10] = 1, dp[0] = 1을 채울 수 있다.
젤 마지막엔 dp[0] = 3, dp[10]=3이 나오고, 
마지막 연주인 3번째 연주에서 가장 큰 볼륨은 10이기 때문에 10이 정답이 된다.

### list 사용
plus랑 minus 2개씩 나오는데, dp배열에 바로 업데이트 하지않고 list를 써서 나중에 업데이트하는 이유는, 같은 단계 내에서 다른 볼륨 계산을 할 때 영향을 줄 수 있기 때문이다.

나중에 복습 해야할듯..ㅎ
<br/>

## **💬** 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>
