### PR TITLE
[1209] 1753번 - 최단경로

### DIFF
--- a/src/Baekjoon/algorithm/graph/Q1753.java
+++ b/src/Baekjoon/algorithm/graph/Q1753.java
@@ -1,0 +1,85 @@
+package Baekjoon.algorithm.graph;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+// 틀린 답안
+// -> 가중치 그래프에서 BFS는 절대 쓸 수 없음 !!!
+// -> 가중치 그래프는 한 정점에 여러번 방문할 수 있어서 방문처리 어려움 !!
+public class Q1753 {
+    static Queue<int[]> queue;
+    static List<List<int[]>> graph;
+    static boolean[] visited;
+    static int[] distance;
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int V = Integer.parseInt(st.nextToken()); // 정점 개수
+        int E = Integer.parseInt(st.nextToken()); // 간선 개수
+
+        int K = Integer.parseInt(br.readLine()); // 시작 정점
+
+        graph = new ArrayList<>();
+        for (int i = 0; i <= V; i++) {
+            graph.add(new ArrayList<>());
+        }
+
+        for (int i = 0; i < E; i++) {
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            int w = Integer.parseInt(st.nextToken());
+
+            graph.get(u).add(new int[]{v, w});
+        }
+
+        queue = new LinkedList<>();
+        queue.add(new int[]{K, 0});
+        visited = new boolean[V];
+        visited[K] = true;
+        distance = new int[V+1];
+        for (int i = 1; i <= V; i++) {
+            distance[i] = Integer.MAX_VALUE;
+            if (i == K) {
+                distance[i] = 0;
+            }
+        }
+        bfs();
+
+        for (int i = 1; i <= V; i++) {
+            if(distance[i] == Integer.MAX_VALUE) {
+                System.out.println("INF");
+            }
+            else{
+                System.out.println(distance[i]+" ");
+            }
+        }
+    }
+
+    static void bfs() {
+        while(!queue.isEmpty()) {
+            int[] cur = queue.poll();
+            int num = cur[0];
+            int dis = cur[1];
+            System.out.println("num = " + num+" dis = " + dis);
+
+            distance[num] = Math.min(dis,distance[num]);
+
+            for (int[] next : graph.get(num)) {
+                int nextNum = next[0];
+                int nextDis = next[1];
+                if(!visited[nextNum]) {
+                    visited[nextNum] = true;
+                    queue.add(new int[]{nextNum, dis+nextDis});
+                }
+            }
+        }
+    }
+}

--- a/src/Baekjoon/algorithm/graph/Q1753_2.java
+++ b/src/Baekjoon/algorithm/graph/Q1753_2.java
@@ -1,0 +1,90 @@
+package Baekjoon.algorithm.graph;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.PriorityQueue;
+import java.util.StringTokenizer;
+
+public class Q1753_2 {
+    static PriorityQueue<int[]> pq;
+    static List<List<int[]>> graph;
+    static boolean[] visited; // pq에서 꺼낸 정점이 '최단거리 확정'되었음 표시
+    static int[] distance; // 시작점에서 i까지의 최단거리
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int V = Integer.parseInt(st.nextToken()); // 정점 개수
+        int E = Integer.parseInt(st.nextToken()); // 간선 개수
+
+        int K = Integer.parseInt(br.readLine()); // 시작 정점
+
+        graph = new ArrayList<>();
+        for (int i = 0; i <= V; i++) {
+            graph.add(new ArrayList<>());
+        }
+
+        for (int i = 0; i < E; i++) {
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            int w = Integer.parseInt(st.nextToken());
+
+            graph.get(u).add(new int[]{v, w});
+        }
+
+        distance = new int[V+1];
+        // 초기화
+        for (int i = 1; i <= V; i++) {
+            distance[i] = Integer.MAX_VALUE;
+        }
+        distance[K] = 0;
+
+        visited = new boolean[V+1];
+
+        // PriorityQueue : 가장 비용이 적은 정점부터 꺼냄
+        pq = new PriorityQueue<>((a,b) -> Integer.compare(a[1],b[1])); // 두번째 원소인 '가중치'로 비교
+        pq.add(new int[]{K, 0});
+        dijkstra();
+
+        for (int i = 1; i <= V; i++) {
+            if(distance[i] == Integer.MAX_VALUE) {
+                System.out.println("INF");
+            }
+            else{
+                System.out.println(distance[i]+" ");
+            }
+        }
+    }
+
+    static void dijkstra() {
+        while(!pq.isEmpty()) {
+            int[] cur = pq.poll();
+            int nowVertex = cur[0];
+            int nowCost = cur[1]; // 지금까지 온 비용
+            // System.out.println("nowVertex = " + nowVertex +" nowCost = " + nowCost);
+
+            // 한번 pq에서 나온 최단거리 노드는 다시 처리할 필요 없음
+            if(visited[nowVertex]) {
+                continue;
+            }
+            visited[nowVertex] = true;
+
+            for (int[] next : graph.get(nowVertex)) {
+                int nextVertex = next[0];
+                int nextCost = next[1]; // next로 가는 비용
+
+                // 새로운 비용 = 지금까지 온 비용 + next로 가는 비용
+                int newDist = nowCost + nextCost;
+                if(distance[nextVertex] > newDist) {
+                    distance[nextVertex] = newDist;
+                    pq.add(new int[]{nextVertex, newDist});
+                }
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
## 📎 문제 링크
https://www.acmicpc.net/problem/1753
<br/>

## 📝 풀이 내용
> 풀이 내용, 고민한 부분 등을 작성해주세요

첨에는 최단경로라해서 bfs로 풀었는데 가중치가 있는 그래프에서는 bfs로 풀 수 없다는 걸 알게 되었다....

그래서 다익스트라를 첨 공부했다!!!
공부한 블로그
https://velog.io/@suk13574/%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98Java%EB%8B%A4%EC%9D%B5%EC%8A%A4%ED%8A%B8%EB%9D%BCDijkstra-%EC%95%8C%EA%B3%A0%EB%A6%AC%EC%A6%98

뭔가 bfs랑 비슷하게 생긴 듯... dp 같기도 하고..

다익스트라의 특징은
- **PriorityQueue** 쓴다
  - **가중치가 작은** 정점부터 꺼내 쓰기 위함
- 방문 처리를 하긴 하지만 
  - bfs는 **큐에 넣는 순간** 방문 처리
  - 다익스트라는 **pq에서 poll된 순간** 방문 처리를 한다
- 이유는 방문 처리의 목적이 다르기 때문이다
  - bfs는 한번만 방문하기 위해서고
    - bfs는 간선 가중치가 모두 1이라, 처음 방문하는 순간이 최단 거리가 보장됨.
  - 다익스트라는 여러번 방문할 수는 있지만, pq에서 꺼냈다면 이미 가장 비용이 작은 값으로 업데이트를 했기 때문에 **더이상 볼 필요 없다**고 표시해놓기 위해서이다. 
<br/>

## **💬** 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>
