### PR TITLE
[1226] 문자열 4문제 

### DIFF
--- a/src/Baekjoon/algorithm/string/Q1427.java
+++ b/src/Baekjoon/algorithm/string/Q1427.java
@@ -1,0 +1,21 @@
+package Baekjoon.algorithm.string;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.Arrays;
+
+public class Q1427 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        String str = br.readLine();
+        char[] arr = str.toCharArray();
+
+        Arrays.sort(arr);
+
+        for (int i = arr.length - 1; i >= 0; i--) {
+            System.out.print(arr[i]);
+        }
+    }
+}

--- a/src/Baekjoon/algorithm/string/Q1764.java
+++ b/src/Baekjoon/algorithm/string/Q1764.java
@@ -1,0 +1,43 @@
+package Baekjoon.algorithm.string;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.StringTokenizer;
+
+// 틀린 답안 -> 시간 초과
+public class Q1764 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        String[] arr = new String[N];
+        for (int i = 0; i < N; i++) {
+            String str = br.readLine();
+            arr[i] = str;
+        }
+
+        List<String> list = new ArrayList<>();
+        for (int i = 0; i < M; i++) {
+            String str = br.readLine();
+            for (int j = 0; j < N; j++) {
+                if(arr[j].equals(str)) {
+                    list.add(str);
+                }
+            }
+        }
+
+        Collections.sort(list);
+
+        System.out.println(list.size());
+        for (String str : list) {
+            System.out.println(str);
+        }
+    }
+}

--- a/src/Baekjoon/algorithm/string/Q1764_2.java
+++ b/src/Baekjoon/algorithm/string/Q1764_2.java
@@ -1,0 +1,42 @@
+package Baekjoon.algorithm.string;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.StringTokenizer;
+
+public class Q1764_2 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int N = Integer.parseInt(st.nextToken());
+        int M = Integer.parseInt(st.nextToken());
+
+        Set<String> set = new HashSet<>();
+        for (int i = 0; i < N; i++) {
+            String str = br.readLine();
+            set.add(str);
+        }
+
+        List<String> list = new ArrayList<>();
+        for (int i = 0; i < M; i++) {
+            String str = br.readLine();
+            if(set.contains(str)) {
+                list.add(str);
+            }
+        }
+
+        Collections.sort(list);
+
+        System.out.println(list.size());
+        for (String str : list) {
+            System.out.println(str);
+        }
+    }
+}

--- a/src/Baekjoon/algorithm/string/Q9251.java
+++ b/src/Baekjoon/algorithm/string/Q9251.java
@@ -1,0 +1,29 @@
+package Baekjoon.algorithm.string;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Q9251 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        String first = br.readLine();
+        String second = br.readLine();
+
+        int[][] dp = new int[first.length()+1][second.length()+1];
+
+        for (int i = 1; i <= first.length(); i++) {
+            for (int j = 1; j <= second.length(); j++) {
+                if (first.charAt(i-1) == second.charAt(j-1)) {
+                    dp[i][j] = dp[i-1][j-1] + 1;
+                }
+                else{
+                    dp[i][j] = Math.max(dp[i-1][j], dp[i][j-1]); // first or second의 현재 문자 버리기
+                }
+            }
+        }
+
+        System.out.println(dp[first.length()][second.length()]);
+    }
+}

--- a/src/Baekjoon/algorithm/string/Q9251.java
+++ b/src/Baekjoon/algorithm/string/Q9251.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
+// LCS
 public class Q9251 {
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));

--- a/src/Baekjoon/algorithm/string/Q9252.java
+++ b/src/Baekjoon/algorithm/string/Q9252.java
@@ -1,0 +1,51 @@
+package Baekjoon.algorithm.string;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Q9252 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        String first = br.readLine();
+        String second = br.readLine();
+
+        int[][] dp = new int[first.length()+1][second.length()+1];
+
+        for (int i = 1; i <= first.length(); i++) {
+            for (int j = 1; j <= second.length(); j++) {
+                if (first.charAt(i-1) == second.charAt(j-1)) {
+                    dp[i][j] = dp[i-1][j-1] + 1;
+                }
+                else{
+                    dp[i][j] = Math.max(dp[i-1][j], dp[i][j-1]); // first or second의 현재 문자 버리기
+                }
+            }
+        }
+
+        System.out.println(dp[first.length()][second.length()]);
+
+        int i = first.length();
+        int j = second.length();
+        String LCS = "";
+        while (i > 0 && j > 0) {
+            if(first.charAt(i-1) == second.charAt(j-1)) {
+                LCS += first.charAt(i - 1);
+                i--;
+                j--;
+            }
+            else{
+                if(dp[i-1][j] > dp[i][j-1]) {
+                    i--;
+                }
+                else{
+                    j--;
+                }
+            }
+        }
+        for (int c = LCS.length() - 1; c >= 0; c--) {
+            System.out.print(LCS.charAt(c));
+        }
+    }
+}

--- a/src/Baekjoon/algorithm/string/Q9252.java
+++ b/src/Baekjoon/algorithm/string/Q9252.java
@@ -4,6 +4,7 @@ import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 
+// LCS 2
 public class Q9252 {
     public static void main(String[] args) throws IOException {
         BufferedReader br = new BufferedReader(new InputStreamReader(System.in));


### PR DESCRIPTION
## 📎 문제 링크
https://www.acmicpc.net/problem/1427
https://www.acmicpc.net/problem/1764
https://www.acmicpc.net/problem/9251
https://www.acmicpc.net/problem/9252
<br/>

## 📝 풀이 내용
> 풀이 내용, 고민한 부분 등을 작성해주세요

9251는 LCS  길이를 구하고, 9252는 LCS 글자까지 구해야 하는 문제였다.

LCS는 **dp**가 핵심인데
- 두 문자열을 비교하면서 같은 문자가 나오면 길이+1(해당 문자를 추가)를 해준다.
- 문자가 다를 경우에는 첫째 문자열의 현재 문자를 버릴건지 둘째 문자열의 현재 문자를 버릴건지 선택해야 한다. (둘 중 더 긴 걸 선택하면 된다.) 

글자까지 구할 때는 뒤에서부터 **역추적**을 하면 된다.
두 문자열을 비교하면서 문자가 같으면 LCS에 추가해주고, 인덱스를 둘 다 하나씩 내려준다.
문자가 다를 경우에는 dp값이 유지된 방향으로 인덱스를 내려주면 된다. 
마지막에 출력할 때는 거꾸로 출력해야 한다. (뒤에서부터 추가해줬기 때문)


넘 헷갈렸당,,,,!!!!ㅠ

<br/>

## **💬** 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>
