### PR TITLE
[0105] 16933번 - 벽 부수고 이동하기 3

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,10 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="DuplicatedCode" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <Languages>
+        <language minSize="68" name="Java" />
+      </Languages>
+    </inspection_tool>
+  </profile>
+</component>

--- a/src/Problem16933.java
+++ b/src/Problem16933.java
@@ -1,0 +1,83 @@
+import java.io.*;
+import java.util.*;
+
+public class Problem16933 {
+    static int N, M, K;
+    static char[][] grid;
+    static final int[] dx = {1, -1, 0, 0};
+    static final int[] dy = {0, 0, 1, -1};
+
+    static class State {
+        int x, y, broken, day;
+        State(int x, int y, int broken, int day) {
+            this.x = x;
+            this.y = y;
+            this.broken = broken;
+            this.day = day;
+        }
+    }
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        M = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        grid = new char[N][M];
+        for (int i = 0; i < N; i++) grid[i] = br.readLine().toCharArray();
+
+        int[][][][] dist = new int[N][M][K + 1][2];
+        ArrayDeque<State> q = new ArrayDeque<>();
+
+        dist[0][0][0][0] = 1;
+        q.add(new State(0, 0, 0, 0));
+
+        while (!q.isEmpty()) {
+            State cur = q.poll();
+            int d = dist[cur.x][cur.y][cur.broken][cur.day];
+
+            if (cur.x == N - 1 && cur.y == M - 1) {
+                bw.write(String.valueOf(d));
+                bw.newLine();
+                bw.flush();
+                return;
+            }
+
+            int nd = 1 - cur.day;
+
+            for (int i = 0; i < 4; i++) {
+                int nx = cur.x + dx[i];
+                int ny = cur.y + dy[i];
+
+                if (nx < 0 || nx >= N || ny < 0 || ny >= M) continue;
+
+                if (grid[nx][ny] == '0') {
+                    if (dist[nx][ny][cur.broken][nd] == 0) {
+                        dist[nx][ny][cur.broken][nd] = d + 1;
+                        q.add(new State(nx, ny, cur.broken, nd));
+                    }
+                } else {
+                    if (cur.day == 0 && cur.broken < K) {
+                        int nb = cur.broken + 1;
+                        if (dist[nx][ny][nb][nd] == 0) {
+                            dist[nx][ny][nb][nd] = d + 1;
+                            q.add(new State(nx, ny, nb, nd));
+                        }
+                    }
+                }
+            }
+
+            if (dist[cur.x][cur.y][cur.broken][nd] == 0) {
+                dist[cur.x][cur.y][cur.broken][nd] = d + 1;
+                q.add(new State(cur.x, cur.y, cur.broken, nd));
+            }
+        }
+
+        bw.write("-1");
+        bw.newLine();
+        bw.flush();
+    }
+}


### PR DESCRIPTION
## 📎 문제 링크
https://www.acmicpc.net/problem/16933
<br/>

## 📝 풀이 내용
> 풀이 내용, 고민한 부분 등을 작성해주세요

처음엔 메모리 걱정을 하다가 계속 잘못된 풀이를 해...
실패하자는 마음으로 4차원 배열을 썼습니다.

근데 메모리 초과가 아닌 시간초과가 떠...

실행 시간을 줄이는 방향으로 코딩을 하기 시작했습니다.

1. 우선 큐를 사용할 때 LinkedList를 사용해왔는데 그것보다 ArrayDeque가 더 빠르다고 하여 ArrayDeque를 사용했습니다.
2. 큐에서 int[]를 생성해 큐에 넣기보다 State객체를 생성해 큐에 저장했습니다.
3. 입력 파싱에서 charAt +""을 int로 바꾸기 보다 br.readLine().toCharArray()로 line 자체를 char 배열로 만들었습니다.
4. 4차원 배열인 visited를 전부 false로 초기화 시켰습니다. 근데 코드를 보니 굳이 초기화가 필요 없을 듯 하여 제거했습니다.
**5. dist 배열을 만들고 그 값을 큐에 별도로 저장하지 않았습니다.**


이렇게 해서 메모리랑 실행 시간을 최소화 했던 거 같습니다.

## **💬** 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>
