### PR TITLE
[0124] 17071번 - 숨바꼭질 5

### DIFF
--- a/src/Problem17071.java
+++ b/src/Problem17071.java
@@ -1,0 +1,77 @@
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.InputStreamReader;
+import java.io.BufferedWriter;
+import java.io.BufferedReader;
+import java.util.Arrays;
+import java.util.StringTokenizer;
+import java.util.ArrayDeque;
+
+public class Problem17071 {
+    public static final int MAX_VALUE = 500001;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int m = Integer.parseInt(st.nextToken()); // 수빈 위치
+        int n = Integer.parseInt(st.nextToken()); // 동생 위치
+        int time = 0;
+        int size = 0;
+        boolean[][] map = new boolean[2][MAX_VALUE];
+
+        ArrayDeque<Integer> q = new ArrayDeque<>();
+
+        q.add(m); // 수빈 위치, time, sum할 값
+        map[0%2][m] = true;
+
+        while (!q.isEmpty()) {
+            size = q.size();
+            n = n + time;
+
+            if(n > MAX_VALUE-1) {
+                break;
+            }
+
+            for (int i = 0; i < size; i++) {
+                int current = q.poll();
+                int nextTime = (time + 1) % 2;
+
+                if(map[time % 2][n]) {
+                    bw.write(String.valueOf(time));
+                    bw.flush();
+                    bw.close();
+                    return;
+                }
+
+                if(current * 2 < MAX_VALUE) {
+                    if (!map[nextTime][current * 2]) {
+                        map[nextTime][current * 2] = true;
+                        q.add(current*2);
+                    }
+                }
+
+                if(current + 1 < MAX_VALUE) {
+                    if (!map[nextTime][current + 1]) {
+                        map[nextTime][current + 1] = true;
+                        q.add(current + 1);
+                    }
+                }
+
+                if(current - 1 >= 0) {
+                    if (!map[nextTime][current - 1]) {
+                        map[nextTime][current - 1] = true;
+                        q.add(current - 1);
+                    }
+                }
+            }
+            time++;
+
+        }
+
+        bw.write("-1");
+        bw.flush();
+        bw.close();
+    }
+}


### PR DESCRIPTION
## 📎 문제 링크
https://www.acmicpc.net/problem/17071
<br/>

## 📝 풀이 내용
> 풀이 내용, 고민한 부분 등을 작성해주세요

문제 자체는 쉬웠으나... 시간제한이 0.25초인점이 너무 어려웠습니다...

**가정 1**

동생이 움직일때마다 초기화 시키기

⇒ 시간 초과

**가정 2**

큐를 넣는 조건 다시 검토

1. 2배의 경우 아직 방문하지 않았고, 내가 목표 보다 뒤에 있는 경우
2. 방문하지 않았거나 목표가 나보다 뒤인 경우

시간 복잡도의 경우:  O(5×10^8) → 더 줄여야함

홀짝성

시간은 홀수짝수 변경

⇒ 

홀수 짝수에 따라 배열로 방문 처리

⇒ 시간 초과

원인 1)

Arrays.fill(map[time%2], false)

이 과정으로 문제 풀이 진행하였습니다.

이 문제의 포인트는 홀수 시간에, 짝수 시간에 방문한 위치는 언제든지 다시 방문할 수 있다는 점인 거 같습니다!

이를 이용해서 홀수 시간, 짝수 시간 방문 배열을 다시 채웠고,

매번 큐에서 꺼낸 값과 목표 값을 직접 비교했는데!

이번에는 visitied 배열에서 true면 바로 값을 출력하게 로직을 구상했습니다.

<br/>

## **💬** 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>
