### PR TITLE
[0717] 42627번 - 디스크 컨트롤러, 42628번 - 이중우선순위큐 

### DIFF
--- a/src/programmers/algorithm/heap/Q42627.java
+++ b/src/programmers/algorithm/heap/Q42627.java
@@ -1,0 +1,61 @@
+package programmers.algorithm.heap;
+
+import java.util.*;
+
+class Q42627 {
+    public int solution(int[][] jobs) {
+        int answer = 0;
+
+        PriorityQueue<int[]> pq = new PriorityQueue<>(
+                (a,b)-> {
+                    int cmp = a[2]-b[2];
+                    if(cmp!=0){
+                        return cmp;
+                    }
+                    int cmp2 = a[1]-b[1];
+                    if(cmp2!=0){
+                        return cmp2;
+                    }
+                    return a[0]-b[0];
+                });
+
+        Arrays.sort(jobs,(a,b)->a[0]-b[0]);
+
+        int sum = 0;
+        int currentTime = 0;
+        int index = 0;
+        int completed = 0;
+
+        while(completed < jobs.length){
+            while(index<jobs.length
+                    && jobs[index][0] <= currentTime){
+                pq.offer(new int[]{index,jobs[index][0],jobs[index][1]});
+                index++;
+            }
+
+            if(!pq.isEmpty()){
+
+                int[] now = pq.poll();
+
+                int requestTime = now[1];
+                int duration = now[2];
+
+                currentTime += duration;
+
+                int returnTime = currentTime-requestTime;
+
+                sum += returnTime;
+
+                completed++;
+            }
+
+            else{
+                currentTime = jobs[index][0];
+            }
+
+        }
+
+        answer = sum/jobs.length;
+        return answer;
+    }
+}

--- a/src/programmers/algorithm/heap/Q42628.java
+++ b/src/programmers/algorithm/heap/Q42628.java
@@ -1,0 +1,65 @@
+package programmers.algorithm.heap;
+
+import java.util.*;
+
+class Q42628 {
+
+    public int[] solution(String[] operations) {
+        PriorityQueue<Integer> minHeap = new PriorityQueue<>();
+        PriorityQueue<Integer> maxHeap =
+                new PriorityQueue<>(Collections.reverseOrder());
+
+        Map<Integer, Integer> countMap = new HashMap<>();
+
+        for (String operation : operations) {
+            char command = operation.charAt(0);
+            int number = Integer.parseInt(operation.substring(2));
+
+            if (command == 'I') {
+                minHeap.offer(number);
+                maxHeap.offer(number);
+
+                countMap.put(
+                        number,
+                        countMap.getOrDefault(number, 0) + 1
+                );
+            } else if (number == 1) {
+                clean(maxHeap, countMap);
+
+                if (!maxHeap.isEmpty()) {
+                    int max = maxHeap.poll();
+                    countMap.put(max, countMap.get(max) - 1);
+                }
+            } else {
+                clean(minHeap, countMap);
+
+                if (!minHeap.isEmpty()) {
+                    int min = minHeap.poll();
+                    countMap.put(min, countMap.get(min) - 1);
+                }
+            }
+        }
+
+        clean(minHeap, countMap);
+        clean(maxHeap, countMap);
+
+        if (minHeap.isEmpty() || maxHeap.isEmpty()) {
+            return new int[]{0, 0};
+        }
+
+        return new int[]{
+                maxHeap.peek(),
+                minHeap.peek()
+        };
+    }
+
+    private void clean(
+            PriorityQueue<Integer> pq,
+            Map<Integer, Integer> countMap
+    ) {
+        while (!pq.isEmpty()
+                && countMap.getOrDefault(pq.peek(), 0) == 0) {
+            pq.poll();
+        }
+    }
+}

--- a/src/programmers/algorithm/heap/Q42628_2.java
+++ b/src/programmers/algorithm/heap/Q42628_2.java
@@ -1,0 +1,49 @@
+package programmers.algorithm.heap;
+
+import java.util.*;
+
+class Q42628_2 {
+    public int[] solution(String[] operations) {
+        int[] answer = new int[2];
+        PriorityQueue<Integer> pqMin = new PriorityQueue<>();
+        PriorityQueue<Integer> pqMax = new PriorityQueue<>(Collections.reverseOrder());
+
+        for(String s: operations){
+            int num = Integer.parseInt(s.substring(2));
+            if(s.charAt(0) == 'I'){
+                pqMin.offer(num);
+                pqMax.offer(num);
+            }
+
+            else{
+                if(num == 1){
+                    if(!pqMax.isEmpty()){
+                        int max = pqMax.poll();
+                        pqMin.remove(max);
+                    }
+                }
+                else{
+                    if(!pqMin.isEmpty()){
+                        int min = pqMin.poll();
+                        pqMax.remove(min);
+                    }
+                }
+            }
+        }
+
+        if(pqMin.isEmpty()){
+            answer[0] = 0;
+            answer[1] = 0;
+        }
+
+        else{
+            int max = pqMax.poll();
+            answer[0] = max;
+
+            int min = pqMin.poll();
+            answer[1] = min;
+        }
+
+        return answer;
+    }
+}

--- a/src/programmers/algorithm/heap/Q42628_3.java
+++ b/src/programmers/algorithm/heap/Q42628_3.java
@@ -1,0 +1,49 @@
+package programmers.algorithm.heap;
+
+import java.util.*;
+
+class Q42628_3 {
+
+    public int[] solution(String[] operations) {
+        TreeMap<Integer, Integer> treeMap = new TreeMap<>();
+
+        for (String operation : operations) {
+            char command = operation.charAt(0);
+            int number = Integer.parseInt(operation.substring(2));
+
+            if (command == 'I') {
+                treeMap.put(
+                        number,
+                        treeMap.getOrDefault(number, 0) + 1
+                );
+            } else {
+                if (treeMap.isEmpty()) {
+                    continue;
+                }
+
+                int key;
+
+                if (number == 1) {
+                    key = treeMap.lastKey();
+                } else {
+                    key = treeMap.firstKey();
+                }
+
+                if (treeMap.get(key) == 1) {
+                    treeMap.remove(key);
+                } else {
+                    treeMap.put(key, treeMap.get(key) - 1);
+                }
+            }
+        }
+
+        if (treeMap.isEmpty()) {
+            return new int[]{0, 0};
+        }
+
+        return new int[]{
+                treeMap.lastKey(),
+                treeMap.firstKey()
+        };
+    }
+}


### PR DESCRIPTION
## 📎 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/42627
https://school.programmers.co.kr/learn/courses/30/lessons/42628
<br/>

## 📝 풀이 내용
> 풀이 내용, 고민한 부분 등을 작성해주세요

### 42627번
1. 현재 시각까지 요청된 작업을 전부 큐에 넣는다.
2. 그중 소요 시간이 가장 짧은 작업 하나만 꺼낸다.
3. 작업을 처리해서 현재 시각을 증가시킨다.
4. 증가한 현재 시각까지 새로 요청된 작업을 다시 큐에 넣는다. 

### 42628번
- 시도 1. pq2개 + map
min용, max용 2개의 pq를 쓰고 map에서 개수를 계속 추적해준다.
map에서 개수가 0인 값이 힙의 맨 위에 나타나면 poll()로 제거해 힙의 상태를 맞춘다. (lazy deletion이라 한다고 함...ㅎ)

- 시도 2. pq2개 + remove
굳이 map 쓰지 않고 그냥 remove로 없애는 방법이 있었다.
pq에서는 루트에 있는최댓값, 최솟값 말고는 뺄 방법이 없다고 생각해서 map이 필요했던건데, 제거할 수 있다면야......위에처럼 굳이 복잡하게 할 필요가 없었따... 
근데 시간복잡도 조심해야한다. (O(N)이고 얘는 일단 통과했다)

- 시도 3. treemap
pq 쓸 필요없이 treemap은 자동 정렬되니까 그냥 양 끝에 있는거 가져다쓰면 된다. 
레드블랙 트리기반이라 삽입, 삭제 다 O(logN)이다. 
단, 주의할 점은 같은 값이 여러번 들어올 수 있기 때문에 value에 해당 숫자의 개수를 저장하고, 삭제할 때 개수가 1이면 키를 제거하고 2 이상이면 개수만 감소시켜야 한다.

<br/>

## **💬** 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>
