### PR TITLE
[0723] 42895번 - N으로 표현, 43105번 - 정수 삼각형, 169199번 - 리코쳇 로봇, 49191번 - 순위

### DIFF
--- a/src/programmers/algorithm/dfsbfs/Q169199.java
+++ b/src/programmers/algorithm/dfsbfs/Q169199.java
@@ -1,0 +1,74 @@
+package programmers.algorithm.dfsbfs;
+
+import java.util.*;
+
+class Q169199 {
+    static int[] dRow = {-1,1,0,0};
+    static int[] dCol = {0,0,-1,1};
+    static int[][] distance;
+    static int endRow, endCol;
+    static Queue<int[]> queue;
+    static int R,C;
+    static char[][] arr;
+    public int solution(String[] board) {
+
+        R = board.length;
+        C = board[0].length();
+
+        // R -> G
+        arr = new char[R][C];
+        distance =  new int[R][C];
+        queue = new LinkedList<>();
+
+        for(int i=0;i<R;i++){
+            Arrays.fill(distance[i],-1);
+
+            for(int j=0;j<C;j++){
+                arr[i][j] = board[i].charAt(j);
+                if(arr[i][j]=='R'){
+                    queue.offer(new int[]{i,j});
+                    distance[i][j] = 0;
+                }
+            }
+        }
+
+        return bfs();
+    }
+
+    static int bfs(){
+        while(!queue.isEmpty()){
+            int[] now = queue.poll();
+            int row = now[0];
+            int col = now[1];
+
+            if(arr[row][col] == 'G'){
+                return distance[row][col];
+            }
+
+            for(int i=0;i<4;i++){
+                int nextRow = row;
+                int nextCol = col;
+
+                while(true){
+                    int movedRow = nextRow+dRow[i];
+                    int movedCol = nextCol+dCol[i];
+
+                    if(movedRow<0 || movedRow>=R
+                            || movedCol<0 || movedCol>=C
+                            || arr[movedRow][movedCol] == 'D'){
+                        break;
+                    }
+                    nextRow = movedRow;
+                    nextCol = movedCol;
+                }
+
+                if(distance[nextRow][nextCol] == -1){
+                    distance[nextRow][nextCol] = distance[row][col]+1;
+                    queue.offer(new int[]{nextRow,nextCol});
+                }
+            }
+        }
+
+        return -1;
+    }
+}

--- a/src/programmers/algorithm/dfsbfs/Q49191.java
+++ b/src/programmers/algorithm/dfsbfs/Q49191.java
@@ -1,0 +1,54 @@
+package programmers.algorithm.dfsbfs;
+
+import java.util.*;
+
+class Q49191 {
+    static boolean[] visited;
+    public int solution(int n, int[][] results) {
+        int answer = 0;
+
+        List<Integer>[] win = new ArrayList[n+1];
+        List<Integer>[] lose = new ArrayList[n+1];
+        for(int i=1;i<=n;i++){
+            win[i] = new ArrayList<>();
+            lose[i] = new ArrayList<>();
+        }
+        for(int[] result: results){
+            int winner = result[0];
+            int loser = result[1];
+
+            win[winner].add(loser);
+            lose[loser].add(winner);
+        }
+
+        for(int i=1;i<=n;i++){
+            visited = new boolean[n+1];
+            int down = dfs(i,win);
+
+            visited = new boolean[n+1];
+            int up = dfs(i,lose);
+
+            if(down+up == n-1){
+                answer++;
+            }
+        }
+
+        return answer;
+    }
+
+    static int dfs(int now, List<Integer>[] graph){
+        visited[now] = true;
+
+        int count = 0;
+
+        for(int next: graph[now]){
+            if(!visited[next]){
+                count++;
+                count += dfs(next,graph);
+            }
+        }
+
+        return count;
+    }
+
+}

--- a/src/programmers/algorithm/dp/Q42895.java
+++ b/src/programmers/algorithm/dp/Q42895.java
@@ -1,0 +1,59 @@
+package programmers.algorithm.dp;
+
+import java.util.*;
+
+class Q42895 {
+    public int solution(int N, int number) {
+        int answer = -1;
+
+        // dp[i] = N을 i개 사용해서 만들 수 있는 모든 숫자 집합, i<=8
+        Set<Integer>[] dp = new HashSet[9];
+
+        for(int i=0;i<=8;i++){
+            dp[i] = new HashSet<>();
+        }
+
+        dp[1].add(N);
+        if(dp[1].contains(number)){
+            answer = 1;
+            return answer;
+        }
+
+        dp[2].add(N+N);
+        dp[2].add(N-N);
+        dp[2].add(N/N);
+        dp[2].add(N*N);
+        dp[2].add(N*10+N);
+        if(dp[2].contains(number)){
+            answer = 2;
+            return answer;
+        }
+
+        for(int i=3;i<=8;i++){
+            for(int j=1;j<i;j++){
+                for(int num1:dp[j]){
+                    for(int num2:dp[i-j]){
+                        dp[i].add(num1+num2);
+                        dp[i].add(num1-num2);
+                        dp[i].add(num1*num2);
+                        if(num2!=0){
+                            dp[i].add(num1/num2);
+                        }
+                    }
+                }
+            }
+            int num = N;
+            for(int j=1;j<=i-1;j++){
+                num = num*10+N;
+            }
+            dp[i].add(num);
+
+            if(dp[i].contains(number)){
+                answer = i;
+                break;
+            }
+        }
+
+        return answer;
+    }
+}

--- a/src/programmers/algorithm/dp/Q43105.java
+++ b/src/programmers/algorithm/dp/Q43105.java
@@ -1,0 +1,40 @@
+package programmers.algorithm.dp;
+
+class Q43105 {
+    public int solution(int[][] triangle) {
+
+        // dp : 해당 위치에 도달할 때까지 합 중 최댓값
+        int[][] dp = new int[triangle.length][];
+        for(int n=0;n<triangle.length;n++){
+            dp[n] = new int[n+1];
+        }
+
+        dp[0][0] = triangle[0][0];
+
+        dp[1][0] = triangle[0][0]+triangle[1][0];
+        dp[1][1] = triangle[0][0]+triangle[1][1];
+
+        for(int n=2;n<triangle.length;n++){
+            dp[n][0] = dp[n-1][0]+triangle[n][0];
+            for(int i=1;i<n;i++){
+                dp[n][i] = Math.max(dp[n-1][i-1],dp[n-1][i])+triangle[n][i];
+            }
+            dp[n][n] = dp[n-1][n-1]+triangle[n][n];
+        }
+
+        /*
+        for(int[] i:dp){
+            for(int num:i){
+                System.out.print(num+" ");
+            }
+            System.out.println();
+        }
+        */
+
+        int max = 0;
+        for(int num: dp[triangle.length-1]){
+            max = Math.max(max, num);
+        }
+        return max;
+    }
+}


### PR DESCRIPTION
## 📎 문제 링크
https://school.programmers.co.kr/learn/courses/30/lessons/42895
https://school.programmers.co.kr/learn/courses/30/lessons/43105
https://school.programmers.co.kr/learn/courses/30/lessons/169199
<br/>

## 📝 풀이 내용
> 풀이 내용, 고민한 부분 등을 작성해주세요

### 42895번 
아 도저히 모르겠어서 gpt한테 힌트달라고 하고 풀었따 ㅎ..
**dp[i]에 N을 i개 사용해서 만들 수 있는 모든 숫자의 집합**을 저장했다. 
dp[1], dp[2]를 미리 정의하고, dp[3]부터는 기존꺼를 조합해서 만든다. 
기존껄 조합할 때는 dp[1]+dp[i-1] ~ dp[i-1]+dp[1] 까지의 경우의 수를 다 구해야되고, 
각 집합의 원소를 서로 사칙연산(+, -, *, /)하여 나온 결과를 dp[i]에 추가한다.
이어붙인 숫자(N, NN, NNN ...)는 이전 DP로 만들 수 없으므로 매번 따로 만들어 dp[i]에 넣어줘야 한다.

### 43105번
**dp[i][j]에 삼각형의 (i, j) 위치까지 도달했을 때 얻을 수 있는 최대 누적합**을 저장했다.
현재 위치로 올 수 있는 경로는 이전 행의 같은 열 (i-1, j)과 이전 열 (i-1, j-1) 두 가지이므로, 두 값 중 큰 값에 현재 숫자를 더해 저장했다.
다만 각 행의 맨 왼쪽과 맨 오른쪽은 도달할 수 있는 이전 위치가 하나뿐이므로 따로 계산했다.
마지막 행에 저장된 값 중 최댓값이 전체 경로의 최대 합이다.

### 169199번
슬라이딩해서 움직이는 거 구현하는게 좀 어려웠다..... 
각 방향으로 더 이상 이동할 수 없을 때까지 좌표를 갱신하고, 최종적으로 멈춘 위치를 아직 방문하지 않았다면 현재 위치까지의 이동 횟수에 1을 더해 저장한 뒤 큐에 넣었다.

### 49191번 
각 선수를 기준으로 이길 수 있는 선수들을 저장한 그래프와, 자신을 이길 수 있는 선수들을 저장한 그래프를 각각 만들었다.
각 선수에서 두 그래프를 기준으로 DFS를 실행하여 자신보다 순위가 낮은 선수 수와 높은 선수 수를 구했다. 두 수의 합이 n - 1이면 자신을 제외한 모든 선수와의 순위 관계를 알 수 있으므로, 해당 선수의 순위를 확정할 수 있다.
-> 낼은 플로이드 워셜로 풀어봐야지..


<br/>

## **💬** 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

<br/>
